### PR TITLE
Declare Peer classes in PHP5ObjectBuilder

### DIFF
--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -3347,6 +3347,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         foreach ($this->getTable()->getForeignKeys() as $fk) {
             $this->declareClassFromBuilder($this->getNewStubObjectBuilder($fk->getForeignTable()));
+            $this->declareClassFromBuilder($this->getNewStubPeerBuilder($fk->getForeignTable()));
             $this->declareClassFromBuilder($this->getNewStubQueryBuilder($fk->getForeignTable()));
             $this->addFKMutator($script, $fk);
             $this->addFKAccessor($script, $fk);
@@ -3717,6 +3718,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $this->addInitRelations($script, $referrers);
         foreach ($referrers as $refFK) {
             $this->declareClassFromBuilder($this->getNewStubObjectBuilder($refFK->getTable()));
+            $this->declareClassFromBuilder($this->getNewStubPeerBuilder($refFK->getTable()));
             $this->declareClassFromBuilder($this->getNewStubQueryBuilder($refFK->getTable()));
             if ($refFK->isLocalPrimaryKey()) {
                 $this->addPKRefFKGet($script, $refFK);
@@ -4363,6 +4365,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         foreach ($this->getTable()->getCrossFks() as $fkList) {
             list($refFK, $crossFK) = $fkList;
             $this->declareClassFromBuilder($this->getNewStubObjectBuilder($crossFK->getForeignTable()));
+            $this->declareClassFromBuilder($this->getNewStubPeerBuilder($crossFK->getForeignTable()));
             $this->declareClassFromBuilder($this->getNewStubQueryBuilder($crossFK->getForeignTable()));
 
             $this->addCrossFKClear($script, $crossFK);


### PR DESCRIPTION
Non-base Peer classes are used in generated Base classes, but are not
declared (thus, no use statement). This was never an issue until we had
the base classes in om in a separate namespace from the non-base class
stuff.

This fix adds calls to declareClassFromBuilder() in a few places where
it was previously just being called for Object and Query classes.
